### PR TITLE
bump msal

### DIFF
--- a/App/api.js
+++ b/App/api.js
@@ -10,7 +10,7 @@ function callApi(endpoint, token) {
         headers: headers
       };
   
-    logMessage('Calling Web API...');
+    logMessage('Calling web API...');
     
     fetch(endpoint, options)
       .then(response => response.json())

--- a/App/authConfig.js
+++ b/App/authConfig.js
@@ -17,6 +17,29 @@ const msalConfig = {
       cacheLocation: "localStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
       storeAuthStateInCookie: false, // If you wish to store cache items in cookies as well as browser cache, set this to "true".
     },
+    system: {
+      loggerOptions: {
+        loggerCallback: (level, message, containsPii) => {
+          if (containsPii) {
+            return;
+          }
+          switch (level) {
+            case msal.LogLevel.Error:
+              console.error(message);
+              return;
+            case msal.LogLevel.Info:
+              console.info(message);
+              return;
+            case msal.LogLevel.Verbose:
+              console.debug(message);
+              return;
+            case msal.LogLevel.Warning:
+              console.warn(message);
+              return;
+          }
+        }
+      }
+    }
   };
   
 /**

--- a/App/authConfig.js
+++ b/App/authConfig.js
@@ -14,7 +14,7 @@ const msalConfig = {
       redirectUri: "http://localhost:6420", // You must register this URI on Azure Portal/App Registration. Defaults to "window.location.href".
     },
     cache: {
-      cacheLocation: "localStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO.
+      cacheLocation: "localStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
       storeAuthStateInCookie: false, // If you wish to store cache items in cookies as well as browser cache, set this to "true".
     },
   };

--- a/App/authConfig.js
+++ b/App/authConfig.js
@@ -14,7 +14,7 @@ const msalConfig = {
       redirectUri: "http://localhost:6420", // You must register this URI on Azure Portal/App Registration. Defaults to "window.location.href".
     },
     cache: {
-      cacheLocation: "localStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
+      cacheLocation: "sessionStorage", // Configures cache location. "sessionStorage" is more secure, but "localStorage" gives you SSO between tabs.
       storeAuthStateInCookie: false, // If you wish to store cache items in cookies as well as browser cache, set this to "true".
     },
     system: {

--- a/App/authPopup.js
+++ b/App/authPopup.js
@@ -77,7 +77,7 @@ function signOut() {
 
     const logoutRequest = {
         postLogoutRedirectUri: msalConfig.auth.redirectUri,
-        redirectMainWindowTo: msalConfig.auth.redirectUri
+        mainWindowRedirectUri: msalConfig.auth.redirectUri
     };
     
     myMSALObj.logoutPopup(logoutRequest).then(() => {

--- a/App/authPopup.js
+++ b/App/authPopup.js
@@ -18,7 +18,6 @@ function selectAccount() {
      */
 
     const currentAccounts = myMSALObj.getAllAccounts();
-    console.log(currentAccounts);
 
     if (currentAccounts.length < 1) {
         return;
@@ -42,7 +41,7 @@ function selectAccount() {
                 // All accounts belong to the same user
                 setAccount(accounts[0]);
             } else {
-                // Multiple users detected
+                // Multiple users detected. Logout all to be on the safe side.
                 signOut();
             };
         } else if (accounts.length === 1) {

--- a/App/authPopup.js
+++ b/App/authPopup.js
@@ -14,11 +14,17 @@ function selectAccount () {
 
     const currentAccounts = myMSALObj.getAllAccounts();
 
-    if (currentAccounts.length === 0) {
+    if (!currentAccounts || currentAccounts.length < 1) {
         return;
     } else if (currentAccounts.length > 1) {
         // Add your account choosing logic here
-        console.log("Multiple accounts detected.");
+        console.log("Multiple accounts detected!");
+        currentAccounts.forEach(acc => console.log(acc));
+
+        // Defaulting to the first account found
+        accountId = currentAccounts[0].homeAccountId;
+        username = currentAccounts[0].username;
+        welcomeUser(username);
     } else if (currentAccounts.length === 1) {
         accountId = currentAccounts[0].homeAccountId;
         username = currentAccounts[0].username;
@@ -30,6 +36,7 @@ function selectAccount () {
 selectAccount();
 
 function handleResponse(response) {
+    console.log(response)
     /**
      * To see the full list of response object properties, visit:
      * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/request-response-object.md#response
@@ -55,16 +62,6 @@ function signIn() {
         .then(handleResponse)
         .catch(error => {
             console.log(error);
-                
-            // Error handling
-            if (error.errorMessage) {
-                // Check for forgot password error
-                // Learn more about AAD error codes at https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-aadsts-error-codes
-                if (error.errorMessage.indexOf("AADB2C90118") > -1) {
-                    myMSALObj.loginPopup(b2cPolicies.authorities.forgotPassword)
-                        .then(response => handlePolicyChange(response));
-                }
-            }
         });
 }
 
@@ -75,13 +72,16 @@ function signOut() {
      * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/request-response-object.md#request
      */
 
-    // Choose which account to logout from.
-    
+    // Choose which account to logout from and the behavior after logout completes.
     const logoutRequest = {
-        account: myMSALObj.getAccountByHomeId(accountId)
+        account: myMSALObj.getAccountByHomeId(accountId),
+        postLogoutRedirectUri: msalConfig.auth.redirectUri,
+        redirectMainWindowTo: msalConfig.auth.redirectUri
     };
     
-    myMSALObj.logout(logoutRequest);
+    myMSALObj.logoutPopup(logoutRequest).then(() => {
+        window.location.reload();
+    });
 }
 
 function getTokenPopup(request) {
@@ -103,8 +103,7 @@ function getTokenPopup(request) {
             return response;
         })
         .catch(error => {
-            console.log(error);
-            console.log("silent token acquisition fails. acquiring token using popup");
+            console.log("Silent token acquisition fails. Acquiring token using popup. \n", error);
             if (error instanceof msal.InteractionRequiredAuthError) {
                 // fallback to interaction when silent call fails
                 return myMSALObj.acquireTokenPopup(request)
@@ -136,21 +135,20 @@ function passTokenToApi() {
 
 function editProfile() {
     myMSALObj.loginPopup(b2cPolicies.authorities.editProfile)
-      .then(response => handlePolicyChange(response));
+        .then(handlePolicyChange)
+        .catch(error => {
+            console.log(error);
+        });
 }
 
 function handlePolicyChange(response) {
-    /**
-     * We need to reject id tokens that were not issued with the default sign-in policy.
-     * "acr" claim in the token tells us what policy is used (NOTE: for new policies (v2.0), use "tfp" instead of "acr").
-     * To learn more about B2C tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
-     */
-
-    if (response.idTokenClaims['acr'] === b2cPolicies.names.editProfile) {
-        window.alert("Profile has been updated successfully. \nPlease sign-in again.");
-        myMSALObj.logout();
-    } else if (response.idTokenClaims['acr'] === b2cPolicies.names.forgotPassword) {
-        window.alert("Password has been reset successfully. \nPlease sign-in with your new password.");
-        myMSALObj.logout();
-    }
+        /**
+         * We need to reject id tokens that were not issued with the default sign-in policy.
+         * "tfp" claim in the token tells us what policy is used (NOTE: legacy policies may use "acr" instead of "tfp").
+         * To learn more about B2C tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
+         */
+         if (response.idTokenClaims['tfp'] === b2cPolicies.names.editProfile) {
+            window.alert("Profile has been updated successfully. \nPlease sign-in again.");
+            myMSALObj.logout();
+        }
 }

--- a/App/authPopup.js
+++ b/App/authPopup.js
@@ -25,8 +25,9 @@ function selectAccount() {
 
         /**
          * Due to the way MSAL caches account objects, the auth response from initiating a user-flow
-         * is cached as a new account. Here we make sure we are selecting the account with homeAccountId
-         * that contains the sign-up/sign-in user-flow, as this is the default flow we initially signed-in with.
+         * is cached as a new account, which results in more than one account in the cache. Here we make
+         * sure we are selecting the account with homeAccountId that contains the sign-up/sign-in user-flow, 
+         * as this is the default flow the user initially signed-in with.
          */
         const accounts = currentAccounts.filter(account =>
             account.homeAccountId.toUpperCase().includes(b2cPolicies.names.signUpSignIn.toUpperCase())
@@ -37,11 +38,12 @@ function selectAccount() {
             );
 
         if (accounts.length > 1) {
+            // localAccountId identifies the entity for which the token asserts information.
             if (accounts.every(account => account.localAccountId === accounts[0].localAccountId)) {
                 // All accounts belong to the same user
                 setAccount(accounts[0]);
             } else {
-                // Multiple users detected. Logout all to be on the safe side.
+                // Multiple users detected. Logout all to be safe.
                 signOut();
             };
         } else if (accounts.length === 1) {
@@ -156,7 +158,11 @@ function passTokenToApi() {
  * https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile_v2 
  */
 function editProfile() {
-    myMSALObj.loginPopup(b2cPolicies.authorities.editProfile)
+    
+    const editProfileRequest = b2cPolicies.authorities.editProfile;
+    editProfileRequest.loginHint = myMSALObj.getAccountByHomeId(accountId).username;
+
+    myMSALObj.loginPopup(editProfileRequest)
         .catch(error => {
             console.log(error);
         });

--- a/App/authRedirect.js
+++ b/App/authRedirect.js
@@ -45,8 +45,9 @@ function selectAccount() {
        
         /**
          * Due to the way MSAL caches account objects, the auth response from initiating a user-flow
-         * is cached as a new account. Here we make sure we are selecting the account with homeAccountId
-         * that contains the sign-up/sign-in user-flow, as this is the default flow we initially signed-in with.
+         * is cached as a new account, which results in more than one account in the cache. Here we make
+         * sure we are selecting the account with homeAccountId that contains the sign-up/sign-in user-flow, 
+         * as this is the default flow the user initially signed-in with.
          */
          const accounts = currentAccounts.filter(account =>
             account.homeAccountId.toUpperCase().includes(b2cPolicies.names.signUpSignIn.toUpperCase())
@@ -57,11 +58,12 @@ function selectAccount() {
             );
 
         if (accounts.length > 1) {
+            // localAccountId identifies the entity for which the token asserts information.
             if (accounts.every(account => account.localAccountId === accounts[0].localAccountId)) {
                 // All accounts belong to the same user
                 setAccount(accounts[0]);
             } else {
-                // Multiple users detected. Logout all to be on the safe side.
+                // Multiple users detected. Logout all to be safe.
                 signOut();
             };
         } else if (accounts.length === 1) {
@@ -166,5 +168,10 @@ function passTokenToApi() {
  * https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile_v2 
  */
 function editProfile() {
-    myMSALObj.loginRedirect(b2cPolicies.authorities.editProfile);
+
+
+    const editProfileRequest = b2cPolicies.authorities.editProfile;
+    editProfileRequest.loginHint = myMSALObj.getAccountByHomeId(accountId).username;
+
+    myMSALObj.loginRedirect(editProfileRequest);
 }

--- a/App/authRedirect.js
+++ b/App/authRedirect.js
@@ -10,8 +10,8 @@ myMSALObj.handleRedirectPromise()
     .then(response => {
         if (response) {
             /**
-             * We need to ignore id tokens that were not issued with the default sign-up/sign-in policy.
-             * "tfp" claim in the token tells us the policy (NOTE: legacy policies may use "acr" instead of "tfp").
+             * For the purpose of setting an active account for UI update, we want to consider only the auth response resulting
+             * from SUSI flow. "tfp" claim in the id token tells us the policy (NOTE: legacy policies may use "acr" instead of "tfp").
              * To learn more about B2C tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
              */
             if (response.idTokenClaims['tfp'].toUpperCase() === b2cPolicies.names.signUpSignIn.toUpperCase()) {
@@ -61,7 +61,7 @@ function selectAccount() {
                 // All accounts belong to the same user
                 setAccount(accounts[0]);
             } else {
-                // Multiple users detected
+                // Multiple users detected. Logout all to be on the safe side.
                 signOut();
             };
         } else if (accounts.length === 1) {

--- a/App/authRedirect.js
+++ b/App/authRedirect.js
@@ -7,7 +7,18 @@ let username = "";
 let accessToken = null;
 
 myMSALObj.handleRedirectPromise()
-    .then(handleResponse)
+    .then(response => {
+        if (response) {
+            /**
+             * We need to reject id tokens that were not issued with the default sign-in policy.
+             * "tfp" claim in the token tells us what policy is used (NOTE: legacy policies may use "acr" instead of "tfp").
+             * To learn more about B2C tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
+             */
+            if (response.idTokenClaims['tfp'].toUpperCase() === b2cPolicies.names.signUpSignIn.toUpperCase()) {
+                handleResponse(response);
+            }
+        }
+    })
     .catch(error => {
         console.log(error);
     });
@@ -23,9 +34,19 @@ function selectAccount() {
 
     if (!currentAccounts || currentAccounts.length < 1) {
         return;
-    } else if (currentAccounts.length > 1) {
-        // Add your account choosing logic here
-        console.log("Multiple accounts detected.");
+    } else if (currentAccounts.length === Object.entries(b2cPolicies.names).length) {
+        
+        /**
+         * Due to the way MSAL caches account objects, the auth response from initiating a user-flow
+         * is cached as a new account. Here we make sure we are selecting the account with homeAccountId
+         * that contains the sign-up/sign-in user-flow.
+         */
+        const account = currentAccounts.find(account => 
+            account.homeAccountId.toUpperCase().includes(b2cPolicies.names.signUpSignIn.toUpperCase()));
+        
+        accountId = account.homeAccountId;
+        username = account.username;
+        welcomeUser(username);
     } else if (currentAccounts.length === 1) {
         accountId = currentAccounts[0].homeAccountId;
         username = currentAccounts[0].username;
@@ -36,22 +57,18 @@ function selectAccount() {
 // in case of page refresh
 selectAccount();
 
-function handleResponse(response) {
+async function handleResponse(response) {
+
     /**
      * To see the full list of response object properties, visit:
      * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/request-response-object.md#response
      */
 
-    if (response) {
-
-        // if response contains an access token, store it
-        if (response.accessToken && response.accessToken !== "") {
-            accessToken = response.accessToken;
-        }
-        
-        // for handling B2C user-flows and policies
-        handlePolicyChange(response);
-
+    if (response !== null) {
+        accountId = response.account.homeAccountId;
+        username = response.account.username;
+        welcomeUser(username);
+    } else {
         selectAccount();
     }
 }
@@ -73,9 +90,7 @@ function signOut() {
      * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/request-response-object.md#request
      */
 
-    // Choose which account to logout from by passing a homeAccountId.
     const logoutRequest = {
-        account: myMSALObj.getAccountByHomeId(accountId),
         postLogoutRedirectUri: msalConfig.auth.redirectUri,
     };
 
@@ -96,11 +111,13 @@ function getTokenRedirect(request) {
             // In case the response from B2C server has an empty accessToken field
             // throw an error to initiate token acquisition
             if (!response.accessToken || response.accessToken === "") {
-                    throw new msal.InteractionRequiredAuthError;
-            } 
-            return handleResponse(response);
-        })
-        .catch(error => {
+                throw new msal.InteractionRequiredAuthError;
+            } else {
+                console.log("access_token acquired at: " + new Date().toString());
+                accessToken = response.accessToken;
+                passTokenToApi();
+            }
+        }).catch(error => {
             console.log("Silent token acquisition fails. Acquiring token using popup. \n", error);
             if (error instanceof msal.InteractionRequiredAuthError) {
                 // fallback to interaction when silent call fails
@@ -124,18 +141,11 @@ function passTokenToApi() {
     }
 }
 
+/**
+ * To initiate a B2C user-flow, simply make a login request using
+ * the full authority string of that user-flow e.g.
+ * https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile_v2 
+ */
 function editProfile() {
     myMSALObj.loginRedirect(b2cPolicies.authorities.editProfile);
-}
-
-function handlePolicyChange(response) {
-    /**
-     * We need to reject id tokens that were not issued with the default sign-in policy.
-     * "tfp" claim in the token tells us what policy is used (NOTE: legacy policies may use "acr" instead of "tfp").
-     * To learn more about B2C tokens, visit https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
-     */
-    if (response.idTokenClaims['tfp'] === b2cPolicies.names.editProfile) {
-        window.alert("Profile has been updated successfully. \nPlease sign-in again.");
-        myMSALObj.logout();
-    }
 }

--- a/App/index.html
+++ b/App/index.html
@@ -7,11 +7,11 @@
     <link rel="SHORTCUT ICON" href="./favicon.svg" type="image/x-icon">
     
     <!-- msal.min.js can be used in the place of msal.js; included msal.js to make debug easy -->
-    <script src="https://alcdn.msauth.net/browser/2.7.0/js/msal-browser.js" integrity="sha384-5Fqyq1ncNYhL2mXCdWAFXkf2wWtKeA0mXYp++ryAX1lowD0ctAHFdity37L/ULXh" crossorigin="anonymous"></script>
+    <script src="https://alcdn.msauth.net/browser/2.13.1/js/msal-browser.js" integrity="sha384-7hwr87O1w6buPsX92CwuRaz/wQzachgOEq+iLHv0ESavynv6rbYwKImSl7wUW3wV" crossorigin="anonymous"></script>
 
     <!-- To help ensure reliability, Microsoft provides a second CDN -->
     <script type="text/javascript">
-      if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/browser/2.7.0/js/msal-browser.js' type='text/javascript' crossorigin='anonymous' %3E%3C/script%3E"));
+      if(typeof Msal === 'undefined')document.write(unescape("%3Cscript src='https://alcdn.msftauth.net/browser/2.13.1/js/msal-browser.js' type='text/javascript' crossorigin='anonymous' %3E%3C/script%3E"));
     </script>
 
     <!-- adding Bootstrap 4 for UI components  -->
@@ -27,12 +27,12 @@
       </div>
     </nav>
     <br>
-    <h5 id="title-div" class="card-header text-center">Vanilla JavaScript Single-page Application built with MSAL.js</h5>
+    <h5 id="title-div" class="card-header text-center">Vanilla JavaScript single-page application built with MSAL.js</h5>
     <h5 id="welcome-div" class="card-header text-center d-none"></h5>
     <br>
     <!-- Content -->
     <div class="card">
-      <h5 class="card-header text-center">Getting an access token with Azure AD B2C and calling a Web API</h5>
+      <h5 class="card-header text-center">Getting an access token with Azure AD B2C and calling a web API</h5>
       <div class="card-body text-center">
         <h5 id="label" class="card-title">Sign-in with Microsoft Azure AD B2C</h5>
         <pre id="response" class="card-text"></pre>

--- a/App/policies.js
+++ b/App/policies.js
@@ -5,19 +5,15 @@
  */
 const b2cPolicies = {
     names: {
-        signUpSignIn: "b2c_1_susi",
-        forgotPassword: "b2c_1_reset",
-        editProfile: "b2c_1_edit_profile"
+        signUpSignIn: "b2c_1_susi_reset_v2",
+        editProfile: "b2c_1_edit_profile_v2"
     },
     authorities: {
         signUpSignIn: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
-        },
-        forgotPassword: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_reset",
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi_reset_v2",
         },
         editProfile: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_edit_profile"
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_edit_profile_v2"
         }
     },
     authorityDomain: "fabrikamb2c.b2clogin.com"

--- a/App/policies.js
+++ b/App/policies.js
@@ -5,15 +5,15 @@
  */
 const b2cPolicies = {
     names: {
-        signUpSignIn: "b2c_1_susi_reset_v2",
-        editProfile: "b2c_1_edit_profile_v2"
+        signUpSignIn: "B2C_1_susi_reset_v2",
+        editProfile: "B2C_1_edit_profile_v2"
     },
     authorities: {
         signUpSignIn: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi_reset_v2",
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_susi_reset_v2",
         },
         editProfile: {
-            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_edit_profile_v2"
+            authority: "https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/B2C_1_edit_profile_v2"
         }
     },
     authorityDomain: "fabrikamb2c.b2clogin.com"

--- a/App/ui.js
+++ b/App/ui.js
@@ -11,13 +11,15 @@ const response = document.getElementById("response");
 const label = document.getElementById('label');
 
 function welcomeUser(username) {
+    welcomeDiv.innerHTML = `Welcome ${username}!`
+
     label.classList.add('d-none');
     signInButton.classList.add('d-none');
-    signOutButton.classList.remove('d-none');
     titleDiv.classList.add('d-none');
+
+    signOutButton.classList.remove('d-none');
     editProfileButton.classList.remove('d-none');
     welcomeDiv.classList.remove('d-none');
-    welcomeDiv.innerHTML = `Welcome ${username}!`
     callApiButton.classList.remove('d-none');
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 04/09/2021
+
+* Updated MSAL.js to 2.13.1
+* Added combined SUSI user flow with password reset feature.
+* Added logoutPopup and logoutRedirect APIs.
+
 ## 11/23/2020
 
 * Updated MSAL.js to 2.7.0

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ languages:
 products:
   - azure-active-directory-b2c
   - microsoft-identity-platform
-name: JavaScript Single-page Application secured with MSAL.js using the Authorization Code Flow (PKCE) on Azure AD B2C
+name: JavaScript single-page application secured with MSAL.js using the Authorization Code Flow (w/ PKCE) on Azure AD B2C
 urlFragment: ms-identity-b2c-javascript-spa
-description: "This sample demonstrates a Vanilla JavaScript Single-page Application with MSAL.js using the Authorization Code Flow (w/ PKCE) to authorize users to call a Web API protected by Azure Active Directory B2C"
+description: "This sample demonstrates a vanilla JavaScript single-page application with MSAL.js using the Authorization Code Flow (w/ PKCE) to authorize users to call a web API protected by Azure AD B2C"
 ---
 
 # JavaScript Single-page Application secured with MSAL.js using the Authorization Code Flow (PKCE) on Azure AD B2C
@@ -28,7 +28,7 @@ description: "This sample demonstrates a Vanilla JavaScript Single-page Applicat
 
 ## Overview
 
-This sample demonstrates a Vanilla JavaScript single-page application that lets users authenticate against [Azure Active Directory B2C](https://azure.microsoft.com/services/active-directory/external-identities/b2c/) (Azure AD B2C) using the [Microsoft Authentication Library for JavaScript](https://github.com/AzureAD/microsoft-authentication-library-for-js) (MSAL.js) and authorize them to call a web API that is also protected by **Azure AD B2C**.
+This sample demonstrates a vanilla JavaScript single-page application (SPA) that lets users authenticate against [Azure Active Directory B2C](https://azure.microsoft.com/services/active-directory/external-identities/b2c/) (Azure AD B2C) using the [Microsoft Authentication Library for JavaScript](https://github.com/AzureAD/microsoft-authentication-library-for-js) (MSAL.js) and authorize them to call a web API that is also protected by **Azure AD B2C**.
 
 ## Scenario
 
@@ -38,7 +38,7 @@ This sample demonstrates a Vanilla JavaScript single-page application that lets 
 
 ![Overview](./ReadmeFiles/topology.png)
 
-If you like, you can take a [quick look to the application](https://azure-samples.github.io/ms-identity-b2c-javascript-spa/) before trying.
+If you like, you can take a [quick look at the application](https://azure-samples.github.io/ms-identity-b2c-javascript-spa/) before trying.
 
 ## Contents
 
@@ -53,9 +53,9 @@ If you like, you can take a [quick look to the application](https://azure-sample
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/en/download/) must be installed to run this sample.
-- A modern web browser. This sample uses **ES6** conventions and will not run on **Internet Explorer**.
 - [Visual Studio Code](https://code.visualstudio.com/download) is recommended for running and editing this sample.
 - [VS Code Azure Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack) extension is recommended for interacting with Azure through VS Code Interface.
+- A modern web browser. This sample uses **ES6** conventions and will not run on **Internet Explorer**.
 - An Azure Active Directory B2C (Azure AD B2C) tenant. For more information, see: [Create an Azure Active Directory B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant)
 - A user account in your Azure AD B2C tenant.
 
@@ -135,7 +135,7 @@ Open the `App\authConfig.js` file. Then:
 
 Open the `App\policies.js` file. Then:
 
-1. Find the key `policies.names` and replace it with the names (IDs) of your policies/user-flows e.g. `b2c_1_susi`.
+1. Find the key `policies.names` and replace it with the names (IDs) of your policies/user-flows e.g. `b2c_1_susi_reset_v2`.
 1. Find the key `policies.authorities` abd replace it with the authority strings of your policies/user-flows e.g. `https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi`.
 1. Find the key `policies.authorityDomain` abd replace it with the domain of your authority e.g. `fabrikamb2c.b2clogin.com`.
 
@@ -170,7 +170,7 @@ There is one single-page application in this sample. To deploy it to **Azure Sto
 - build your project and upload it
 - update config files with website coordinates
 
-If you are going to call a web API from a your deployed SPA, you'll also need to configure your web API's **CORS** setting accordingly (more on this below). 
+If you are going to call a web API from a your deployed SPA, you'll also need to configure your web API's **CORS** setting accordingly (more on this below).
 
 > :information_source: If you would like to use **VS Code Azure Tools** extension for deployment, [watch the tutorial](https://docs.microsoft.com/azure/developer/javascript/tutorial-vscode-static-website-node-01) offered by Microsoft Docs.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ urlFragment: ms-identity-b2c-javascript-spa
 description: "This sample demonstrates a vanilla JavaScript single-page application with MSAL.js using the Authorization Code Flow (w/ PKCE) to authorize users to call a web API protected by Azure AD B2C"
 ---
 
-# JavaScript Single-page Application secured with MSAL.js using the Authorization Code Flow (PKCE) on Azure AD B2C
+# JavaScript single-page application secured with MSAL.js using the Authorization Code Flow (PKCE) on Azure AD B2C
 
  1. [Overview](#overview)
  1. [Scenario](#scenario)
@@ -24,11 +24,10 @@ description: "This sample demonstrates a vanilla JavaScript single-page applicat
  1. [More information](#more-information)
  1. [Community Help and Support](#community-help-and-support)
  1. [Contributing](#contributing)
- 1. [Code of Conduct](#code-of-conduct)
 
 ## Overview
 
-This sample demonstrates a vanilla JavaScript single-page application (SPA) that lets users authenticate against [Azure Active Directory B2C](https://azure.microsoft.com/services/active-directory/external-identities/b2c/) (Azure AD B2C) using the [Microsoft Authentication Library for JavaScript](https://github.com/AzureAD/microsoft-authentication-library-for-js) (MSAL.js) and authorize them to call a web API that is also protected by **Azure AD B2C**.
+This sample demonstrates a vanilla JavaScript single-page application (SPA) that lets users authenticate against [Azure Active Directory B2C](https://azure.microsoft.com/services/active-directory/external-identities/b2c/) (Azure AD B2C) using the [Microsoft Authentication Library for JavaScript](https://github.com/AzureAD/microsoft-authentication-library-for-js) (MSAL.js) and authorize them to call a web API that is also protected by **Azure AD B2C**. This sample also demonstrates sign-up/sign-in, password reset and profile edit [user-flows](https://docs.microsoft.com/azure/active-directory-b2c/user-flow-overview).
 
 ## Scenario
 
@@ -47,7 +46,7 @@ If you like, you can take a [quick look at the application](https://azure-sample
 | `App/authPopup.js`    | Main authentication logic resides here (using popup flow). |
 | `App/authRedirect.js` | Use this instead of `authPopup.js` for authentication with redirect flow. |
 | `App/authConfig.js`   | Contains configuration parameters for the sample. |
-| `App/apiConfig.js`    | Contains Web API scopes and coordinates. |
+| `App/apiConfig.js`    | Contains web API scopes and coordinates. |
 | `App/policies.js`     | Contains B2C custom policies and user-flows.  |
 
 ## Prerequisites
@@ -56,7 +55,7 @@ If you like, you can take a [quick look at the application](https://azure-sample
 - [Visual Studio Code](https://code.visualstudio.com/download) is recommended for running and editing this sample.
 - [VS Code Azure Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-node-azure-pack) extension is recommended for interacting with Azure through VS Code Interface.
 - A modern web browser. This sample uses **ES6** conventions and will not run on **Internet Explorer**.
-- An Azure Active Directory B2C (Azure AD B2C) tenant. For more information, see: [Create an Azure Active Directory B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant)
+- An Azure AD B2C tenant. For more information, see: [Create an Azure Active Directory B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/tutorial-create-tenant)
 - A user account in your Azure AD B2C tenant.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Open the `App\authConfig.js` file. Then:
 Open the `App\policies.js` file. Then:
 
 1. Find the key `policies.names` and replace it with the names (IDs) of your policies/user-flows e.g. `b2c_1_susi_reset_v2`.
-1. Find the key `policies.authorities` abd replace it with the authority strings of your policies/user-flows e.g. `https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi`.
+1. Find the key `policies.authorities` abd replace it with the authority strings of your policies/user-flows e.g. `https://fabrikamb2c.b2clogin.com/fabrikamb2c.onmicrosoft.com/b2c_1_susi_reset_v2`.
 1. Find the key `policies.authorityDomain` abd replace it with the domain of your authority e.g. `fabrikamb2c.b2clogin.com`.
 
 Open the `App\apiConfig.js` file. Then:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ms-identity-b2c-javascript-spa",
   "version": "1.0.0",
-  "description": "A Vanilla JavaScript Single-page Application secured with MSAL.js",
+  "description": "A Vanilla JavaScript single-page application secured with MSAL.js",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Bumped msal-browser to 2.13.1
* Added new combined SUSI user flow with password reset (B2C_1_susi_reset_v2)
* Added new msal.js logout APIs (logoutPopup, logoutRedirect)
* Added a simple filter for choosing the correct account when there are multiple accounts in cache due to initiating a user-flow like edit profile (ps. this can be improved)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ x ] Other... Please describe: package update
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/ms-identity-b2c-javascript-spa.git
cd ms-identity-b2c-javascript-spa
git checkout derisen
npm install
```

## What to Check
Verify that the following are valid
1) sign-in
2) call API
3) edit profile
4) reset password and repeat 2, 3

## Other Information

Strangely, when returning from password reset, initiating edit profile user-flow prompts a sign-in screen. This does not happen if you initiate edit-profile after a normal sign-in. I'm suspecting that there is a difference between the session cookie issued after normal sign-in and after returning from password reset. @nickgmicrosoft @tnorling any insights on this?